### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 This project provides a flexible Model Context Protocol (MCP) server, powered by [Probe](https://probeai.dev/), designed to make documentation or codebases searchable by AI assistants.
 
+<a href="https://glama.ai/mcp/servers/@buger/docs-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@buger/docs-mcp/badge" alt="Docs Server MCP server" />
+</a>
+
 You can chat with code or your docs, simply by pointing to git repo or a folder.
 ```
 npx -y @buger/docs-mcp@latest --gitUrl https://github.com/buger/probe


### PR DESCRIPTION
This PR adds a badge for the [Docs MCP Server](https://glama.ai/mcp/servers/@buger/docs-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@buger/docs-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@buger/docs-mcp/badge" alt="Docs Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.