### PR TITLE
Enhance loadConfig with ignorePatterns

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -74,6 +74,7 @@ export function loadConfig() {
 	if (process.env.DATA_DIR) config.dataDir = process.env.DATA_DIR;
 	if (process.env.TOOL_NAME) config.toolName = process.env.TOOL_NAME;
 	if (process.env.TOOL_DESCRIPTION) config.toolDescription = process.env.TOOL_DESCRIPTION;
+	if (process.env.IGNORE_PATTERNS) config.ignorePatterns = process.env.IGNORE_PATTERNS.split(',').map(p => p.trim());
 
 	// Override with command line arguments
 	if (args.includeDir) config.includeDir = args.includeDir;
@@ -83,6 +84,7 @@ export function loadConfig() {
 	if (args.dataDir) config.dataDir = args.dataDir;
 	if (args.toolName) config.toolName = args.toolName;
 	if (args.toolDescription) config.toolDescription = args.toolDescription;
+	if (args.ignorePatterns) config.ignorePatterns = Array.isArray(args.ignorePatterns) ? args.ignorePatterns : args.ignorePatterns.split(',').map(p => p.trim());
 	if (args.enableBuildCleanup !== undefined) config.enableBuildCleanup = args.enableBuildCleanup === true || args.enableBuildCleanup === 'true';
 
 	// Ensure dataDir is an absolute path


### PR DESCRIPTION
This pull request updates the `loadConfig` function in `src/config.js` to add support for handling `ignorePatterns` from both environment variables and command-line arguments. The changes ensure that `ignorePatterns` is processed consistently as an array.

### Enhancements to configuration handling:

* Added support for `IGNORE_PATTERNS` environment variable, which is split into an array of trimmed strings and assigned to `config.ignorePatterns`. (`src/config.js`, [src/config.jsR77](diffhunk://#diff-23821ae067a9c7dfb6227774aefb39fa3951a5874ea953b9401dfc80175c026cR77))
* Enhanced command-line argument handling for `ignorePatterns` to ensure it is either directly assigned if already an array or split into an array of trimmed strings if passed as a comma-separated string. (`src/config.js`, [src/config.jsR87](diffhunk://#diff-23821ae067a9c7dfb6227774aefb39fa3951a5874ea953b9401dfc80175c026cR87))