### PR TITLE
Add reusable GitHub Actions workflow for simplified MCP releases

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   publish-npm:
-    name: Publish @probelabs/probe-docs-mcp to npm
+    name: Publish @probelabs/docs-mcp to npm
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -27,11 +27,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18" # Or your preferred Node.js version
+          node-version: "18"
           registry-url: "https://registry.npmjs.org/"
           scope: "@probelabs"
-          # The token is implicitly used by setup-node to configure .npmrc
-          # No need to explicitly pass NODE_AUTH_TOKEN to setup-node
 
       - name: Install dependencies
         run: npm install
@@ -48,5 +46,4 @@ jobs:
       - name: Publish to npm
         run: npm publish --access public
         env:
-          # Use the secret token for the publish command
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -1,0 +1,116 @@
+name: Reusable MCP Release Workflow
+
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        description: 'NPM package name'
+        required: true
+        type: string
+      package-description:
+        description: 'Package description'
+        required: false
+        type: string
+        default: 'MCP Server'
+      entry-point:
+        description: 'Main entry file'
+        required: false
+        type: string
+        default: 'src/index.js'
+      include-folders:
+        description: 'Folders to include (comma-separated)'
+        required: false
+        type: string
+        default: 'src,data,bin'
+      include-files:
+        description: 'File patterns to include (comma-separated)'
+        required: false
+        type: string
+        default: '*.json,*.md,LICENSE'
+      dependencies:
+        description: 'Additional dependencies as JSON'
+        required: false
+        type: string
+        default: '{}'
+      build-command:
+        description: 'Build command to run'
+        required: false
+        type: string
+        default: ''
+      node-version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '18'
+    secrets:
+      NPM_TOKEN:
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Extract Version
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Create Package JSON
+        run: |
+          # Convert comma-separated to JSON array
+          FOLDERS='${{ inputs.include-folders }}'
+          FILES='${{ inputs.include-files }}'
+
+          FILES_ARRAY='['
+          for folder in ${FOLDERS//,/ }; do
+            FILES_ARRAY="$FILES_ARRAY\"${folder}/**/*\","
+          done
+          for file in ${FILES//,/ }; do
+            FILES_ARRAY="$FILES_ARRAY\"${file}\","
+          done
+          FILES_ARRAY="${FILES_ARRAY%,}]"
+
+          # Default MCP dependencies
+          BASE_DEPS='{
+            "@modelcontextprotocol/sdk": "^1.6.0",
+            "@probelabs/probe": "^0.6.0-rc128",
+            "axios": "^1.7.2",
+            "fs-extra": "^11.1.1"
+          }'
+
+          # Merge with custom dependencies
+          MERGED_DEPS=$(echo "$BASE_DEPS" | jq -s '.[0] * .[1]' - <(echo '${{ inputs.dependencies }}'))
+
+          cat > package.json << EOF
+          {
+            "name": "${{ inputs.package-name }}",
+            "version": "$VERSION",
+            "description": "${{ inputs.package-description }}",
+            "type": "module",
+            "main": "${{ inputs.entry-point }}",
+            "files": $FILES_ARRAY,
+            "dependencies": $MERGED_DEPS,
+            "keywords": ["mcp", "llm", "ai"],
+            "license": "MIT"
+          }
+          EOF
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        if: inputs.build-command != ''
+        run: ${{ inputs.build-command }}
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -242,6 +242,103 @@ npx -y @smithery/cli install @probelabs/docs-mcp --client claude
 
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/probelabs-docs-mcp-badge.png)](https://mseep.ai/app/probelabs-docs-mcp)
 
+## Automated NPM Releases with GitHub Actions
+
+This project includes a reusable GitHub Actions workflow that makes releasing MCP servers to NPM incredibly simple. You can use this workflow in any project to automatically build and publish your MCP server when you push a git tag.
+
+### Using the Reusable Release Workflow
+
+To use this automated release system in your own project, create a single file `.github/workflows/release.yml`:
+
+```yaml
+name: Release MCP
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    uses: probelabs/docs-mcp/.github/workflows/release-mcp.yml@main
+    with:
+      package-name: '@yourorg/your-mcp-server'
+      package-description: 'Your MCP Server Description'
+      include-folders: 'src,data,bin'  # Folders to include in the package
+      include-files: '*.json,*.md'     # File patterns to include
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+Then simply create a git tag to trigger a release:
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+### Workflow Input Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `package-name` | Yes | - | NPM package name (e.g., `@org/my-mcp`) |
+| `package-description` | No | `MCP Server` | Package description |
+| `entry-point` | No | `src/index.js` | Main entry file path |
+| `include-folders` | No | `src,data,bin` | Comma-separated list of folders to include |
+| `include-files` | No | `*.json,*.md,LICENSE` | Comma-separated list of file patterns |
+| `dependencies` | No | `{}` | Additional dependencies as JSON string |
+| `build-command` | No | - | Build command to run before publishing |
+| `node-version` | No | `18` | Node.js version to use |
+
+### Example Configurations
+
+#### Minimal Configuration
+```yaml
+jobs:
+  release:
+    uses: probelabs/docs-mcp/.github/workflows/release-mcp.yml@main
+    with:
+      package-name: '@myorg/simple-mcp'
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+#### With Custom Dependencies
+```yaml
+jobs:
+  release:
+    uses: probelabs/docs-mcp/.github/workflows/release-mcp.yml@main
+    with:
+      package-name: '@myorg/custom-mcp'
+      dependencies: '{"lodash": "^4.17.21", "dotenv": "^16.0.0"}'
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+#### With Build Step
+```yaml
+jobs:
+  release:
+    uses: probelabs/docs-mcp/.github/workflows/release-mcp.yml@main
+    with:
+      package-name: '@myorg/built-mcp'
+      build-command: 'npm run build && npm run prepare-data'
+      include-folders: 'dist,assets'
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+### Prerequisites
+
+1. Add `NPM_TOKEN` secret to your GitHub repository (Settings → Secrets → Actions)
+2. Ensure you have npm publish access for your organization/scope
+
+The workflow automatically:
+- Extracts version from git tags (e.g., `v1.0.0` → `1.0.0`)
+- Generates a complete `package.json` with MCP dependencies
+- Runs optional build commands
+- Publishes to NPM with public access
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Created a reusable GitHub Actions workflow for releasing MCP servers to NPM
- Simplified the release process to just workflow inputs - no config files needed
- Added comprehensive documentation to the README

## What's New

### Reusable Workflow (`release-mcp.yml`)
The workflow automatically:
- Extracts version from git tags (v1.0.0 → 1.0.0)
- Generates complete package.json from inputs
- Handles dependencies, build commands, and file inclusion
- Publishes to NPM with public access

### Usage Example
Projects can now release MCP servers with just:
```yaml
jobs:
  release:
    uses: probelabs/docs-mcp/.github/workflows/release-mcp.yml@main
    with:
      package-name: '@org/my-mcp-server'
      include-folders: 'src,data'
    secrets:
      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
```

Then: `git tag v1.0.0 && git push origin v1.0.0`

### Barcelona Project
Added the workflow to Barcelona project for releasing `@gates/visor-docs-mcp`

## Test plan
- [ ] Review the workflow configuration
- [ ] Test with a sample tag push
- [ ] Verify package.json generation logic
- [ ] Check NPM publishing permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)